### PR TITLE
Profile Photo Integration

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_BASE_URL=https://d3pund969mpxv.cloudfront.net/api
+VITE_BASE_URL=https://tickwebapi.azurewebsites.net/api

--- a/src/apiCalls/user.ts
+++ b/src/apiCalls/user.ts
@@ -43,12 +43,22 @@ export const logoutApiCall = (token: string) => {
 }
 
 export const addUserApiCall = (formValues: SignupFormValues) => {
-  const addUserRequest = {...formValues, userName: formValues.email, role: 2};
+  // Create request body as form data 
+  const formData = new FormData();
+  formData.append("firstName", formValues.firstName);
+  formData.append("lastName", formValues.lastName);
+  formData.append("email", formValues.email);
+  formData.append("userName", formValues.email);
+  formData.append("password", formValues.password);
+  formData.append("role", "2");
+  formData.append("profileImage", formValues.profileImage);
+
+  // Create API call function
   const AddUser = new Promise<ApiCallResponse<string>>((resolve) => {
     api
       .post(
         "/User/addUser",
-        addUserRequest
+        formData
       )
       .then((response: AxiosResponse<ApiResponse<string>>) => {
         resolve({ data: response.data });

--- a/src/apiCalls/user.ts
+++ b/src/apiCalls/user.ts
@@ -45,13 +45,14 @@ export const logoutApiCall = (token: string) => {
 export const addUserApiCall = (formValues: SignupFormValues) => {
   // Create request body as form data 
   const formData = new FormData();
-  formData.append("firstName", formValues.firstName);
-  formData.append("lastName", formValues.lastName);
-  formData.append("email", formValues.email);
+  const properties: (keyof SignupFormValues)[] = ["firstName", "lastName", "email", "password", "profileImage"];
+  for (const property of properties) {
+    formData.append(property, formValues[property]);
+  }
+
+  // Add properties not provided by the SignUp form
   formData.append("userName", formValues.email);
-  formData.append("password", formValues.password);
   formData.append("role", "2");
-  formData.append("profileImage", formValues.profileImage);
 
   // Create API call function
   const AddUser = new Promise<ApiCallResponse<string>>((resolve) => {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,10 +1,9 @@
+import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { AppDispatch, RootState } from "../../store/store";
 import { HeaderProps } from "../../models";
 import { logoutUser } from "../../store/usersSlice";
-
-import LinkText from "../LinkText";
 
 // ----------------------  END IMPORTS ---------------------------------
 
@@ -19,11 +18,19 @@ function Header({ goToPage }: HeaderProps) {
         dispatch(logoutUser({ token: token! }))
             .then((response) => {
                 if (response.type === "logoutUser/fulfilled") {
+                    // Hide dropdown
+                    setIsDropdownVisible(false);
+                    // Go to dashboard
                     goToPage(e);
                 }
             });
 
     }
+
+    const [isDropdownVisible, setIsDropdownVisible] = useState(false);
+    const toggleDropdown = () => {
+        setIsDropdownVisible(!isDropdownVisible);
+    };
 
     return (
         <div className="Header h-14 bg-green flex justify-between items-center px-12 ">
@@ -33,8 +40,38 @@ function Header({ goToPage }: HeaderProps) {
             </div>
             <div className="text-neutral-100">
                 {
-                    (currentUser?.id)
-                        ? <LinkText text="Log out" goToPage={logout} />
+                    (currentUser?.id) ?
+                        <div
+                            className="flex *:my-auto border-2 rounded-md py-1 px-2 gap-2 hover:cursor-pointer"
+                            onClick={toggleDropdown}>
+                            <i
+                                id="logoutDropdown"
+                                className={isDropdownVisible ? "bi-caret-up" : "bi-caret-down"}
+                                aria-expanded={isDropdownVisible}
+                                aria-haspopup="true" />
+                            {
+                                isDropdownVisible &&
+                                (
+                                    <div
+                                        className="absolute top-[3.3rem] right-[1.9rem] rounded-md bg-neutral-100 border border-neutral-70"
+                                        role="menu"
+                                        aria-orientation="vertical"
+                                        aria-labelledby="logoutDropdown"
+                                        tabIndex={-1}>
+                                        <div role="none">
+                                            <div
+                                                className="flex p-2 text-neutral-400 border-neutral-100 hover:text-neutral-0"
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                                onClick={logout}>
+                                                <i className="bi-box-arrow-left"></i> <p className="ms-2">Logout</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                )
+                            }
+                            <img className="size-[30px] rounded-full" src={currentUser.profileImageUrl} alt={currentUser.firstName} />
+                        </div>
                         : null
                 }
             </div>

--- a/src/components/Task/index.tsx
+++ b/src/components/Task/index.tsx
@@ -50,7 +50,7 @@ function Task({ id, details, isImportant, isCompleted }: TaskProps) {
                     isDropdownVisible &&
                     (
                         <div
-                            className="absolute ruonded-md bg-neutral-100 border border-neutral-70 rounded-md"
+                            className="absolute bg-neutral-100 border border-neutral-70 rounded-md"
                             role="menu"
                             aria-orientation="vertical"
                             aria-labelledby="taskOptionsButton"

--- a/src/models.ts
+++ b/src/models.ts
@@ -20,6 +20,8 @@ export type SignupFormValues = {
     lastName: string
     email: string
     password: string
+    confirmPassword: string
+    profileImage: File
 }
 
 export type ResetUserProps = {
@@ -89,8 +91,8 @@ export type UserModel = {
     lastLoginTime: string
     lastName: string
     username: string
+    profileImageUrl: string
 }
-
 
 export type HeaderProps = {
     goToPage: MouseEventHandler

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -14,15 +14,38 @@ import LinkText from "../../components/LinkText";
 // ----------------------  END IMPORTS ---------------------------------
 
 function Signup({ goToPage }: SignupProps) {
+    const [ fileName, setFileName ] = useState("");
     const dispatch = useDispatch<AppDispatch>();
 
     const { signUpErrorMessage } = useSelector((state: RootState) => state.usersReducer);
-    
+
     const {
         handleSubmit,
         register,
         formState: { errors },
+        setValue,
+        getValues
     } = useForm<SignupFormValues>({ resolver: yupResolver(SignupFormSchema) });
+
+    const fileInputField = useRef<any>(null);
+
+    const handleImageUploadClick = () => {
+        // Trigger the onClick action for the <input type=file /> element
+        fileInputField.current?.click();
+    };
+
+    const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {        
+        const files = event.target.files;
+        if (files && files.length > 0) {
+            const reader = new FileReader();
+            reader.readAsDataURL(files[0]);
+            reader.onload = () => {
+                setValue("profileImage", files[0]);
+                setFileName(files[0].name);
+                console.log(getValues(), " >>> form values");
+            };
+        }
+    };
 
     const onSubmit: SubmitHandler<SignupFormValues> = (data) => {
         // Add user
@@ -35,9 +58,9 @@ function Signup({ goToPage }: SignupProps) {
     }
 
     const [showPassword, setShowPassword] = useState(false);
-    const togglePassword = () => {
-        setShowPassword(!showPassword)
-    }
+    const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+    const togglePassword = () => setShowPassword(!showPassword);
+    const toggleConfirmPassword = () => setShowConfirmPassword(!showConfirmPassword);
 
     return (
         <div className="Signup h-full flex flex-col md:flex-row">
@@ -99,6 +122,45 @@ function Signup({ goToPage }: SignupProps) {
                             </div>
                             <p className={"font-tabular text-small " + (errors.password ? "text-red-pure" : "invisible")}>
                                 {errors.password?.message || "Placeholder"}
+                            </p>
+                        </div>
+
+                        {/* Confirm Password */}
+                        <div className="LongTextInput flex flex-col mb-1 md:mb-3">
+                            <label className="font-tabular text-inputLabel">Confirm Password</label>
+                            <div className="flex border border-neutral-0 rounded-md p-1.5 focus-within:border-2 focus-within:p-[0.3rem]">
+                                <input  {...register("confirmPassword")} type={showConfirmPassword ? "text" : "password"} className="font-tabular font-medium text-inputText w-full focus:outline-none focus:border-none"></input>
+                                <i className={(showConfirmPassword ? "bi-eye-slash" : "bi-eye") + " text-neutral-0 text-icon-regular mr-2"} onClick={toggleConfirmPassword} />
+                            </div>
+                            <p className={"font-tabular text-small " + (errors.confirmPassword ? "text-red-pure" : "invisible")}>
+                                {errors.confirmPassword?.message || "Placeholder"}
+                            </p>
+                        </div>
+
+                        {/* Profile Image Upload */}
+                        <div className="LongTextInput flex flex-col mb-1 md:mb-3">
+                            <label className="font-tabular text-inputLabel" htmlFor="profileImage">Upload Profile Photo</label>
+                            <div className="text-1xl">
+                                <div
+                                    className="border border-neutral-0 border-dotted rounded-md flex flex-col items-center py-4 hover:cursor-pointer"
+                                    onClick={handleImageUploadClick}>
+                                    <i className="bi-upload text-neutral-0 text-icon-regular mr-2" />
+                                    <p className="font-tabular">Drag and Drop file here or <span className="underline">Choose file</span></p>
+                                </div>
+                                
+                                <p className="font-tabular text-neutral-400">{fileName ? fileName : "No file chosen"}</p>
+
+                                <input
+                                    {...register("profileImage")}
+                                    ref={fileInputField}
+                                    type="file"
+                                    accept=".jpg, .png, .jpeg, .gif, svg, webp, "
+                                    onChange={handleFileChange}
+                                    className="hidden"
+                                />
+                            </div>
+                            <p className={"font-tabular text-small " + (errors.profileImage ? "text-red-pure" : "invisible")}>
+                                {errors.profileImage?.message || "Placeholder"}
                             </p>
                         </div>
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,5 +1,13 @@
 import * as yup from "yup";
 
+// const validFileExtensions: { [key: string]: string[] } = {
+//     image: ['jpg', 'gif', 'png', 'jpeg', 'svg', 'webp']
+// };
+
+// function isValidFileType(fileName: string, fileType: keyof typeof validFileExtensions): boolean {
+//     return validFileExtensions[fileType].indexOf(fileName.split('.').pop()!) > -1;
+// }
+
 export const SignupFormSchema = yup.object().shape({
     firstName: yup
         .string()
@@ -20,6 +28,16 @@ export const SignupFormSchema = yup.object().shape({
         .matches(/^(?=.*[0-9]).{8,}$/, "Entry must contain at least one number")
         .matches(/^(?=.*[!@#$%^&*(),.?\":{}|<>]).{8,}$/, "Entry must contain at least one special character")
         .matches(/^(?!.* ).{8,}$$/, "Entry must NOT contain a space"),
+    confirmPassword: yup
+        .string()
+        .required("Entry is required")
+        .oneOf([yup.ref('password')], 'Passwords must match'),
+    profileImage: yup
+        .mixed<File>()
+        .required("File upload is required")
+        // .test("is-valid-type", "Not a valid image type", (file) => {
+        //     return isValidFileType(file!.name.toLowerCase(), "image")
+        // })
 });
 
 export const SigninFormSchema = yup.object().shape({


### PR DESCRIPTION
# Profile Photo Integration 
 
### Overview
This PR completes the SignUp and Dashboard functionalities for Tick, as seen in the "Features" section of the `README.md` file. Now, a new user can upload a profile photo on the "Sign up" page and will see said photo in the `Header` component when they log in.

*Issue(s) Referenced: #2*

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Changes Made
* Add `confirmPassword` and `profileImage` fields to `SignUp` form
* Add validation for newly-created `confirmPassword` and `profileImage` fields to the Yup schema
* Update `addUserApiCall()` to send form-data instead of `raw/JSON`, to enable sending a file
* Update logout in `Header` component from a `LinkText` component to a `<div>` that matches the Figma design
* Remove unnecessary class from `Task` component

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
